### PR TITLE
Fix Meson editable installs on Conda/HPC by using Meson Python interpreter and stable build tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,9 @@
 build-backend = "mesonpy"
 
 requires = [
-  "meson-python>=0.13.1",
+  "meson-python>=0.16.0",
+  "meson>=1.9.0",
+  "ninja",
   "nanobind>=2.9.2",
   "numpy>=2",
   "typing-extensions; python_version<'3.11'",


### PR DESCRIPTION
This PR aims to allow one step pip install -e . on clusters, so contributors can install the package without manual meson commands.

Steps to verify:

conda create -n da4ml-test -y python=3.12 pip
conda activate da4ml-test
conda install -y -c conda-forge compilers meson ninja pkg-config

git clone https://github.com/calad0i/da4ml.git
cd da4ml
# (optional, for forks without tags)
git tag v0.0.0

pip install -e . --no-build-isolation
python -c "import da4ml"
python -c "from da4ml._binary import dais_bin"
